### PR TITLE
Minor speedup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.uni-tuebingen.de.it.eager.damageprofiler'
-version '0.3.10'
+version '0.3.11'
 
 buildscript {
     repositories {

--- a/src/main/java/IO/OutputGenerator.java
+++ b/src/main/java/IO/OutputGenerator.java
@@ -30,7 +30,8 @@ import java.io.IOException;
  */
 public class OutputGenerator {
 
-    private final List<String> chrs;
+    //private final List<String> chrs;
+    private int numberOfUsedReads;
     private final double height;
     private final Logger LOG;
     private String outpath;
@@ -50,7 +51,8 @@ public class OutputGenerator {
 
         this.outpath = outputFolder;
         this.frequencies = damageProfiler.getFrequencies();
-        this.chrs = damageProfiler.getChrs();
+        //this.chrs = damageProfiler.getChrs();
+        this.numberOfUsedReads = damageProfiler.getNumberOfUsedReads();
         this.damageProfiler = damageProfiler;
         this.threshold = threshold;
         this.length = length;
@@ -62,9 +64,10 @@ public class OutputGenerator {
             this.specie = specie;
         }
 
-        if(this.length > this.chrs.size()){
-            this.length = this.chrs.size();
-        }
+        // What was this for ??
+        //if(this.length > this.chrs.size(){
+        //    this.length = this.chrs.size();
+        //}
 
 
     }
@@ -255,8 +258,8 @@ public class OutputGenerator {
             double sum=frequencies.getCountA_ref_forward_3()[i]+frequencies.getCountC_ref_forward_3()[i]+
                     frequencies.getCountG_ref_forward_3()[i]+frequencies.getCountT_ref_forward_3()[i];
 
-            if(chrs.size()>0){
-                freq_file_ref.write(chrs.get(i)+"\t3p\t+\t"+(i+1)+"\t"
+            if(this.numberOfUsedReads>0){
+                freq_file_ref.write("fwd\t3p\t+\t"+(i+1)+"\t"
                         +frequencies.getCountA_ref_forward_3()[i]+"\t"+frequencies.getCountC_ref_forward_3()[i]+"\t"
                         +frequencies.getCountG_ref_forward_3()[i]+"\t"+frequencies.getCountT_ref_forward_3()[i]+"\t"
                         +sum+"\t"
@@ -280,8 +283,8 @@ public class OutputGenerator {
             double sum = frequencies.getCountA_ref_reverse_3()[i]+frequencies.getCountC_ref_reverse_3()[i]+
                     frequencies.getCountG_ref_reverse_3()[i]+frequencies.getCountT_ref_reverse_3()[i];
 
-            if(chrs.size()>0){
-                freq_file_ref.write(chrs.get(i)+"\t3p\t-\t"+(i+1)+"\t"
+            if(this.numberOfUsedReads>0){
+                freq_file_ref.write("rev\t3p\t-\t"+(i+1)+"\t"
                         +frequencies.getCountA_ref_reverse_3()[i]+"\t"+frequencies.getCountC_ref_reverse_3()[i]+"\t"
                         +frequencies.getCountG_ref_reverse_3()[i]+"\t"+frequencies.getCountT_ref_reverse_3()[i]+"\t"
                         +sum+"\t"
@@ -306,8 +309,8 @@ public class OutputGenerator {
             double sum = frequencies.getCountA_ref_forward_5()[i]+frequencies.getCountC_ref_forward_5()[i]+
                     frequencies.getCountG_ref_forward_5()[i]+frequencies.getCountT_ref_forward_5()[i];
 
-            if(chrs.size()>0){
-                freq_file_ref.write(chrs.get(i)+"\t5p\t+\t"+(i+1)+"\t"
+            if(this.numberOfUsedReads>0){
+                freq_file_ref.write("fwd\t5p\t+\t"+(i+1)+"\t"
                         +frequencies.getCountA_ref_forward_5()[i]+"\t"+frequencies.getCountC_ref_forward_5()[i]+"\t"
                         +frequencies.getCountG_ref_forward_5()[i]+"\t"+frequencies.getCountT_ref_forward_5()[i]+"\t"
                         +sum+"\t"
@@ -332,8 +335,8 @@ public class OutputGenerator {
             double sum = frequencies.getCountA_ref_reverse_5()[i]+frequencies.getCountC_ref_reverse_5()[i]+
                     frequencies.getCountG_ref_reverse_5()[i]+frequencies.getCountT_ref_reverse_5()[i];
 
-            if(chrs.size()>0){
-                freq_file_ref.write(chrs.get(i)+"\t5p\t-\t"+(i+1)+"\t"
+            if(this.numberOfUsedReads>0){
+                freq_file_ref.write("rev\t5p\t-\t"+(i+1)+"\t"
                         +frequencies.getCountA_ref_reverse_5()[i]+"\t"+frequencies.getCountC_ref_reverse_5()[i]+"\t"
                         +frequencies.getCountG_ref_reverse_5()[i]+"\t"+frequencies.getCountT_ref_reverse_5()[i]+"\t"
                         +sum+"\t"

--- a/src/main/java/calculations/DamageProfiler.java
+++ b/src/main/java/calculations/DamageProfiler.java
@@ -36,7 +36,7 @@ public class  DamageProfiler {
     private FastACacher cache;
     LengthDistribution lengthDistribution;
     private ArrayList<Double> identity;
-    private List<String> chrs;
+    //private List<String> chrs;
 
     /**
      * constructor, set input and output filepaths
@@ -62,7 +62,7 @@ public class  DamageProfiler {
         this.lengthDistribution = new LengthDistribution(this.LOG);
         this.lengthDistribution.init();
         this.identity = new ArrayList();
-        this.chrs = new ArrayList<>();
+        //this.chrs = new ArrayList<>();
         this.specie = specie;
         useful_functions = new Functions(this.LOG);
 
@@ -164,7 +164,7 @@ public class  DamageProfiler {
 
     private void processRecord(SAMRecord record) throws Exception{
         numberOfUsedReads++;
-        chrs.add(record.getReferenceName());
+        //chrs.add(record.getReferenceName());
 
         /*
             If MD value is set, use it to reconstruct reference
@@ -289,5 +289,5 @@ public class  DamageProfiler {
         return numberOfAllReads;
     }
     public ArrayList<Double> getIdentity() { return identity; }
-    public List<String> getChrs() { return chrs; }
+    //public List<String> getChrs() { return chrs; }
 }

--- a/src/main/java/calculations/Frequencies.java
+++ b/src/main/java/calculations/Frequencies.java
@@ -244,12 +244,11 @@ public class Frequencies {
     private double[] count_T_G_5_norm;
     private double[] count_T_G_3_norm;
 
-    private char[] record_char;
-    private char[] record_char_reverse;
+    //private char[] record_char;
+    //private char[] record_char_reverse;
 
-    private char[] ref_char;
-    private char[] ref_char_reverse;
-
+    //private char[] ref_char;
+    //private char[] ref_char_reverse;
 
     private double countA_sample;
     private double countC_sample;
@@ -508,7 +507,6 @@ public class Frequencies {
         count_reverse_T_C_3 = new double[this.length];
         count_reverse_T_G_3 = new double[this.length];
 
-
         countA_ref = 0.0;
         countC_ref = 0.0;
         countG_ref = 0.0;
@@ -530,21 +528,27 @@ public class Frequencies {
      * @param record_aligned
      */
     public void count(SAMRecord record, String record_aligned, String ref_aligned){
-        // get sequence as char from 5' end
-        record_char = record_aligned.toCharArray();
-        ref_char = ref_aligned.toCharArray();
-        // count from 3' end
-        record_char_reverse = new StringBuilder(record_aligned).reverse().toString().toCharArray();
-        ref_char_reverse = new StringBuilder(ref_aligned).reverse().toString().toCharArray();
-
 
         // check whether record is plus of minus strand
         if(record.getReadNegativeStrandFlag()){
 
             // build reverse complement of read
-            String record_aligned_rev_comp = SequenceUtil.reverseComplement(record_aligned);
-            record_char = record_aligned_rev_comp.toCharArray();
-            record_char_reverse = new StringBuilder(record_aligned_rev_comp).reverse().toString().toCharArray();
+            char [] record_char =  SequenceUtil.reverseComplement(record_aligned).toCharArray();
+            char [] record_char_reverse = new char[record_char.length];
+            int i = record_char.length -1;
+            while (i >= 0) {
+              record_char_reverse[record_char.length - 1 - i] = record_char[i];
+              i--;
+            }
+
+            // build reverse complement of reference
+            char [] ref_char =  SequenceUtil.reverseComplement(ref_aligned).toCharArray();
+            char [] ref_char_reverse = new char[ref_char.length];
+            i = ref_char.length -1;
+            while (i >= 0) {
+              ref_char_reverse[ref_char.length - 1 - i] = ref_char[i];
+              i--;
+            }
 
             // count from 5'end
             countBaseFrequency(record_char, this.length, countA_reverse_5, countC_reverse_5,
@@ -552,12 +556,6 @@ public class Frequencies {
             // count from 3'end
             countBaseFrequency(record_char_reverse, this.length, countA_reverse_3, countC_reverse_3,
                     countG_reverse_3, countT_reverse_3, count0_reverse_3, countS_reverse_3);
-
-
-            // build reverse complement of reference
-            String ref_aligned_rev_comp = SequenceUtil.reverseComplement(ref_aligned);
-            ref_char = ref_aligned_rev_comp.toCharArray();
-            ref_char_reverse = new StringBuilder(ref_aligned_rev_comp).reverse().toString().toCharArray();
 
             // count from 5'end
             countBaseFrequency(ref_char, this.length, countA_ref_reverse_5, countC_ref_reverse_5,
@@ -569,13 +567,21 @@ public class Frequencies {
 
         } else {
 
-            // get sequence as char from 5' end
-            record_char = record_aligned.toCharArray();
-            ref_char = ref_aligned.toCharArray();
-            // count from 3' end
-            record_char_reverse = new StringBuilder(record_aligned).reverse().toString().toCharArray();
-            ref_char_reverse = new StringBuilder(ref_aligned).reverse().toString().toCharArray();
+            char [] record_char = record_aligned.toCharArray();
+            char [] record_char_reverse = new char[record_char.length];
+            int i = record_char.length -1;
+            while (i >= 0) {
+              record_char_reverse[record_char.length - 1 - i] = record_char[i];
+              i--;
+            }
 
+            char [] ref_char = ref_aligned.toCharArray();
+            char [] ref_char_reverse = new char[ref_char.length];
+            i = ref_char.length -1;
+            while (i >= 0) {
+              ref_char_reverse[ref_char.length - 1 - i] = ref_char[i];
+              i--;
+            }
 
             // read
             // count from 5'end
@@ -607,24 +613,20 @@ public class Frequencies {
     public void calculateMisincorporations(SAMRecord record, String record_aligned, String reference_aligned) throws Exception{
 
         // count from 3' end
-        record_char_reverse = new StringBuilder(record_aligned).reverse().toString().toCharArray();
 
 
         // get 5'end up to set threshold
         char[] rec_char_5_length = record_aligned.toCharArray();
         char[] ref_char_5_length = reference_aligned.toCharArray();
 
+
         // get 3'end up to set threshold
         char[] rec_char_3_length = new StringBuilder(record_aligned).reverse().toString().toCharArray();
         char[] ref_char_3_length = new StringBuilder(reference_aligned).reverse().toString().toCharArray();
 
-        // init pattern dict
-        List<String> mis_positions = new LinkedList<>();
-
-
         if(!record.getReadNegativeStrandFlag()){
             // forward strand
-            comparePos(rec_char_3_length, ref_char_3_length, mis_positions,
+            comparePos(rec_char_3_length, ref_char_3_length,
                     // count misincorporations
                     this.count_forward_A_C_3, this.count_forward_A_G_3, this.count_forward_A_T_3,
                     this.count_forward_C_A_3, this.count_forward_C_G_3, this.count_forward_C_T_3,
@@ -635,7 +637,7 @@ public class Frequencies {
                     this.count_forward_0_A_3, this.count_forward_0_C_3, this.count_forward_0_G_3,
                     this.count_forward_0_T_3);
 
-            comparePos(rec_char_5_length, ref_char_5_length, mis_positions,
+            comparePos(rec_char_5_length, ref_char_5_length,
                     // count misincorporations
                     this.count_forward_A_C_5, this.count_forward_A_G_5, this.count_forward_A_T_5,
                     this.count_forward_C_A_5, this.count_forward_C_G_5, this.count_forward_C_T_5,
@@ -661,7 +663,7 @@ public class Frequencies {
 
 
 
-            comparePos(rec_char_3_length, ref_char_3_length, mis_positions,
+            comparePos(rec_char_3_length, ref_char_3_length,
                     // count misincorporations
                     this.count_reverse_A_C_3, this.count_reverse_A_G_3, this.count_reverse_A_T_3,
                     this.count_reverse_C_A_3, this.count_reverse_C_G_3, this.count_reverse_C_T_3,
@@ -671,7 +673,7 @@ public class Frequencies {
                     this.count_reverse_T_0_3,
                     this.count_reverse_0_A_3, this.count_reverse_0_C_3, this.count_reverse_0_G_3,
                     this.count_reverse_0_T_3);
-            comparePos(rec_char_5_length, ref_char_5_length, mis_positions,
+            comparePos(rec_char_5_length, ref_char_5_length,
                     // count misincorporations
                     this.count_reverse_A_C_5, this.count_reverse_A_G_5, this.count_reverse_A_T_5,
                     this.count_reverse_C_A_5, this.count_reverse_C_G_5, this.count_reverse_C_T_5,
@@ -681,6 +683,7 @@ public class Frequencies {
                     this.count_reverse_T_0_5,
                     this.count_reverse_0_A_5, this.count_reverse_0_C_5, this.count_reverse_0_G_5,
                     this.count_reverse_0_T_5);
+
 
         }
 
@@ -704,7 +707,7 @@ public class Frequencies {
      * @param t_c
      * @param t_g
      */
-    private void comparePos(char[] seq, char[] ref, List<String> mis_positions, double[] a_c, double[] a_g, double[] a_t,
+    private void comparePos(char[] seq, char[] ref, double[] a_c, double[] a_g, double[] a_t,
                             double[] c_a, double[] c_g, double[] c_t, double[] g_a, double[] g_c, double[] g_t,
                             double[] t_a, double[] t_c, double[] t_g, double[] a_o, double[] c_o, double[] g_o,
                             double[] t_o, double[] o_a, double[] o_c, double[] o_g, double[] o_t){
@@ -746,7 +749,6 @@ public class Frequencies {
                             break;
                         case 'T' :
                             c_t[i]++;
-                            mis_positions.add(i+"");
                             break;
                         case '-' :
                             c_o[i]++;
@@ -759,7 +761,6 @@ public class Frequencies {
                     switch(current_record){
                         case 'A' :
                             g_a[i]++;
-                            mis_positions.add(i+"");
                             break;
                         case 'C' :
                             g_c[i]++;
@@ -810,7 +811,6 @@ public class Frequencies {
         }
         this.length = 100;
     }
-
 
     /**
      * count base frequency of sequence
@@ -1777,5 +1777,3 @@ public class Frequencies {
         return countS_reverse_3;
     }
 }
-
-


### PR DESCRIPTION
10 seconds and 500 Mb of memory on a 500 Mb bam. (10 % faster, 4 % less mem)

Not as much as I would like, but further improvements would more or less require starting again.

Areas to think about:
1. Eliminating the storage of values for each read for drawing the histogram. If the bins could be decided before hand this would no longer be required and should allow DamageProfiler to run in constant memory. This means you would have to set a max length of reads to be plotted.

2. This would be a re-write almost from scratch but it is possible that you would see a speed up from eliminating all copying of sequence data. Pretty hard to do.