### PR TITLE
Fix user display specie -> species

### DIFF
--- a/src/main/java/GUI/Dialogues/ConfigurationDialogue.java
+++ b/src/main/java/GUI/Dialogues/ConfigurationDialogue.java
@@ -57,7 +57,7 @@ public class ConfigurationDialogue {
         Label label_threshold = new Label("Number of bases (x-axis)");
         Label label_yaxis = new Label("Height y-axis");
         Label label_length = new Label("Set number of bases (calculations)");
-        Label label_specie = new Label("Filter for specie");
+        Label label_specie = new Label("Filter for species");
         Label label_title = new Label("Set title");
 
         Label label_plot = new Label("Plot");

--- a/src/main/java/IO/OutputGenerator.java
+++ b/src/main/java/IO/OutputGenerator.java
@@ -995,7 +995,7 @@ public class OutputGenerator {
                         (double)(Math.round(ratio_used_reads*10000))/100 + "% of all input reads)";
             } else{
                 read_per = Chunk.NEWLINE + "Number of used reads: " + df.format(damageProfiler.getNumberOfUsedReads()) + " (" +
-                        (double)(Math.round(ratio_used_reads*10000))/100 + "% of all input reads) | Specie: " + this.specie;
+                        (double)(Math.round(ratio_used_reads*10000))/100 + "% of all input reads) | Species: " + this.specie;
             }
 
         } else {
@@ -1004,7 +1004,7 @@ public class OutputGenerator {
                         (double) (Math.round(ratio_used_reads * 10000)) / 100 + "% of all input reads) | ssLib protocol";
             } else {
                 read_per = Chunk.NEWLINE + "Number of used reads: " + df.format(damageProfiler.getNumberOfUsedReads()) + " (" +
-                        (double) (Math.round(ratio_used_reads * 10000)) / 100 + "% of all input reads) | Specie: " + this.specie + " | ssLib protocol";
+                        (double) (Math.round(ratio_used_reads * 10000)) / 100 + "% of all input reads) | Species: " + this.specie + " | ssLib protocol";
             }
         }
 


### PR DESCRIPTION
Fix user display specie -> species. Minor niggle for me - specie is not a word in English to refer to a singular species (species is both singular and plural).

I should've just checked all 'outward facing' (as in to the user) display, but no internal code variables. Please check code though. 